### PR TITLE
Added use of fully qualified names in place of imports

### DIFF
--- a/protoc_plugins/protoc-gen-php-grpc/php/ns.go
+++ b/protoc_plugins/protoc-gen-php-grpc/php/ns.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	
+
 	desc "google.golang.org/protobuf/types/descriptorpb"
 	plugin "google.golang.org/protobuf/types/pluginpb"
 )

--- a/protoc_plugins/protoc-gen-php-grpc/php/ns.go
+++ b/protoc_plugins/protoc-gen-php-grpc/php/ns.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-
+	
 	desc "google.golang.org/protobuf/types/descriptorpb"
 	plugin "google.golang.org/protobuf/types/pluginpb"
 )
@@ -17,16 +17,16 @@ type ns struct {
 	// Root namespace of the package
 	Namespace string
 
-	// Import declares what namespaces to be imported
-	Import map[string]string
+	// Declares the namespaces of messages used as input and output types for service methods
+	MessageNamespaces map[string]string
 }
 
 // newNamespace creates new work namespace.
 func newNamespace(req *plugin.CodeGeneratorRequest, file *desc.FileDescriptorProto, service *desc.ServiceDescriptorProto) *ns {
 	ns := &ns{
-		Package:   *file.Package,
-		Namespace: namespace(file.Package, "\\"),
-		Import:    make(map[string]string),
+		Package:           *file.Package,
+		Namespace:         namespace(file.Package, "\\"),
+		MessageNamespaces: make(map[string]string),
 	}
 
 	if file.Options != nil && file.Options.PhpNamespace != nil {
@@ -34,15 +34,15 @@ func newNamespace(req *plugin.CodeGeneratorRequest, file *desc.FileDescriptorPro
 	}
 
 	for k := range service.Method {
-		ns.importMessage(req, service.Method[k].InputType)
-		ns.importMessage(req, service.Method[k].OutputType)
+		ns.registerMessageNamespace(req, service.Method[k].InputType)
+		ns.registerMessageNamespace(req, service.Method[k].OutputType)
 	}
 
 	return ns
 }
 
-// importMessage registers new import message namespace (only the namespace).
-func (ns *ns) importMessage(req *plugin.CodeGeneratorRequest, msg *string) {
+// Registers the namespace of a message used as an input or output type for a service method.
+func (ns *ns) registerMessageNamespace(req *plugin.CodeGeneratorRequest, msg *string) {
 	if msg == nil {
 		return
 	}
@@ -64,14 +64,14 @@ func (ns *ns) importMessage(req *plugin.CodeGeneratorRequest, msg *string) {
 	for _, f := range req.ProtoFile {
 		if pkg == "."+*f.Package {
 			if f.Options != nil && f.Options.PhpNamespace != nil {
-				// custom imported namespace
-				ns.Import[pkg] = *f.Options.PhpNamespace
+				// custom message namespace
+				ns.MessageNamespaces[pkg] = *f.Options.PhpNamespace
 				return
 			}
 		}
 	}
 
-	ns.Import[pkg] = strings.Trim(result.String(), `\`)
+	ns.MessageNamespaces[pkg] = strings.Trim(result.String(), `\`)
 }
 
 // resolve message alias
@@ -84,15 +84,14 @@ func (ns *ns) resolve(msg *string) string {
 		return identifier(chunks[len(chunks)-1], "")
 	}
 
-	for iPkg, ns := range ns.Import {
+	for iPkg, ns := range ns.MessageNamespaces {
 		if pkg == iPkg {
 			// use last namespace chunk
-			nsChunks := strings.Split(ns, `\`)
 			identifier := identifier(chunks[len(chunks)-1], "")
 
 			return fmt.Sprintf(
-				`%s\%s`,
-				nsChunks[len(nsChunks)-1],
+				`\%s\%s`,
+				ns,
 				resolveReserved(identifier, pkg),
 			)
 		}

--- a/protoc_plugins/protoc-gen-php-grpc/php/template.go
+++ b/protoc_plugins/protoc-gen-php-grpc/php/template.go
@@ -40,9 +40,6 @@ const phpBody = `<?php
 namespace {{ $ns.Namespace }};
 {{end}}
 use Spiral\RoadRunner\GRPC;
-{{- range $n := $ns.Import}}
-use {{ $n }};
-{{- end}}
 
 interface {{ .Service.Name | interface }} extends GRPC\ServiceInterface
 {

--- a/protoc_plugins/testdata/import/Import/ServiceInterface.php
+++ b/protoc_plugins/testdata/import/Import/ServiceInterface.php
@@ -5,7 +5,6 @@
 namespace Import;
 
 use Spiral\RoadRunner\GRPC;
-use Import\Sub;
 
 interface ServiceInterface extends GRPC\ServiceInterface
 {
@@ -23,10 +22,10 @@ interface ServiceInterface extends GRPC\ServiceInterface
 
     /**
     * @param GRPC\ContextInterface $ctx
-    * @param Sub\Message $in
-    * @return Sub\Message
+    * @param \Import\Sub\Message $in
+    * @return \Import\Sub\Message
     *
     * @throws GRPC\Exception\InvokeException
     */
-    public function ImportMethod(GRPC\ContextInterface $ctx, Sub\Message $in): Sub\Message;
+    public function ImportMethod(GRPC\ContextInterface $ctx, \Import\Sub\Message $in): \Import\Sub\Message;
 }

--- a/protoc_plugins/testdata/import_custom/Test/CustomImport/ServiceInterface.php
+++ b/protoc_plugins/testdata/import_custom/Test/CustomImport/ServiceInterface.php
@@ -5,7 +5,6 @@
 namespace Test\CustomImport;
 
 use Spiral\RoadRunner\GRPC;
-use Test\CustomImport\Message;
 
 interface ServiceInterface extends GRPC\ServiceInterface
 {
@@ -23,10 +22,10 @@ interface ServiceInterface extends GRPC\ServiceInterface
 
     /**
     * @param GRPC\ContextInterface $ctx
-    * @param Message\Message $in
-    * @return Message\Message
+    * @param \Test\CustomImport\Message\Message $in
+    * @return \Test\CustomImport\Message\Message
     *
     * @throws GRPC\Exception\InvokeException
     */
-    public function ImportMethod(GRPC\ContextInterface $ctx, Message\Message $in): Message\Message;
+    public function ImportMethod(GRPC\ContextInterface $ctx, \Test\CustomImport\Message\Message $in): \Test\CustomImport\Message\Message;
 }

--- a/protoc_plugins/testdata/use_empty/Test/ServiceInterface.php
+++ b/protoc_plugins/testdata/use_empty/Test/ServiceInterface.php
@@ -5,7 +5,6 @@
 namespace Test;
 
 use Spiral\RoadRunner\GRPC;
-use Google\Protobuf;
 
 interface ServiceInterface extends GRPC\ServiceInterface
 {
@@ -14,10 +13,10 @@ interface ServiceInterface extends GRPC\ServiceInterface
 
     /**
     * @param GRPC\ContextInterface $ctx
-    * @param Protobuf\GPBEmpty $in
-    * @return Protobuf\GPBEmpty
+    * @param \Google\Protobuf\GPBEmpty $in
+    * @return \Google\Protobuf\GPBEmpty
     *
     * @throws GRPC\Exception\InvokeException
     */
-    public function Test(GRPC\ContextInterface $ctx, Protobuf\GPBEmpty $in): Protobuf\GPBEmpty;
+    public function Test(GRPC\ContextInterface $ctx, \Google\Protobuf\GPBEmpty $in): \Google\Protobuf\GPBEmpty;
 }


### PR DESCRIPTION
# Reason for This PR

An issue with conflicting imports was found while using the protoc-gen-php-grpc plugin. For example, the plugin can potentially create a php file with both of the following imports.
```
use A\Proto;
use B\Proto; 
```
This can become problematic, for example, when the return type for a function in the generated php file is specified as Proto\Message

As a solution to these issues, this commit uses fully qualified names in generated php files in place of imports.

## Description of Changes

- Removed use of imports in generated php files and replaced with use of fully qualified names
- Made corresponding changes to files used for testing

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
